### PR TITLE
Error handling on requesting a preview without specifying a template

### DIFF
--- a/client/src/components/Form/Form.jsx
+++ b/client/src/components/Form/Form.jsx
@@ -114,7 +114,14 @@ class Form extends React.Component {
         redirect: 'follow',
         referrer: 'no-referrer',
         body: JSON.stringify(data),
-      }).then(response => response.json());
+      }).then((response) => {
+        if (response.ok) {
+          return response.json();
+        }
+        return response.json().then((err) => {
+          throw new Error(err.message);
+        });
+      });
     }
 
     const protocol = 'http';
@@ -130,7 +137,7 @@ class Form extends React.Component {
     postData(url, emailData)
       .then(response => this.setState({ previewHTML: response.html, isPreviewDisplayed: true }))
       .catch((error) => {
-        console.log(error);
+        console.error(error);
       });
   }
 

--- a/controllers/helpers.js
+++ b/controllers/helpers.js
@@ -15,12 +15,9 @@ const injectVariablesIntoTemplate = (html, variables) => {
   return template(variables);
 };
 
-const sendError = (err, res, message, data) => {
-  res.json({
-    message,
-    err,
-    data,
-  });
+const sendError = (status, res, message) => {
+  res.status(status);
+  res.send(new Error(message));
 };
 
 module.exports = {

--- a/controllers/helpers.js
+++ b/controllers/helpers.js
@@ -17,7 +17,7 @@ const injectVariablesIntoTemplate = (html, variables) => {
 
 const sendError = (status, res, message) => {
   res.status(status);
-  res.send(new Error(message));
+  res.send({ message });
 };
 
 module.exports = {

--- a/controllers/previewMail.js
+++ b/controllers/previewMail.js
@@ -7,12 +7,12 @@ module.exports = {
     const transpiler = new MJMLTranspiler();
 
     if (!recipients || !currentUser.email) {
-      sendError(true, res, 'ERROR: Invalid sender or recipient(s)!');
+      sendError(400, res, 'ERROR: Invalid sender or recipient(s)!');
       return;
     }
 
     if (!form.mjml) {
-      sendError(true, res, 'ERROR: Must select a template!');
+      sendError(400, res, 'ERROR: Must select a template!');
       return;
     }
     const html = transpiler.transpile(form.mjml);

--- a/controllers/previewMail.js
+++ b/controllers/previewMail.js
@@ -11,6 +11,10 @@ module.exports = {
       return;
     }
 
+    if (!form.mjml) {
+      sendError(true, res, 'ERROR: Must select a template!');
+      return;
+    }
     const html = transpiler.transpile(form.mjml);
 
     const variablesToInject = {

--- a/controllers/sendMail.js
+++ b/controllers/sendMail.js
@@ -20,7 +20,7 @@ module.exports = {
     const emailSender = new EmailSender(transporter);
 
     if (!recipients || !currentUser.email) {
-      sendError(true, res, 'ERROR: Invalid sender or recipient(s)!');
+      sendError(400, res, 'ERROR: Invalid sender or recipient(s)!');
       return;
     }
 


### PR DESCRIPTION
This required a re-write of `sendError`. The function signature was changed from: `(err<Bool>, res<Object>, message<String>, data<any>)` to `(status<Number>, res<Object>, message<String>)`.

We can safely assume that all responses sent from `sendError` are an error, so we can omit the boolean. We'll substitute that with a status code. The data argument was never used, so we can remove it.


Also, a change was made in the Form component to handle errors on the request. Previously, all responses were returned as if they were successful, we should check if the response is `ok` first, and then handle the error accordingly. 